### PR TITLE
Chat streaming functionality update

### DIFF
--- a/add-dummy-chat.py
+++ b/add-dummy-chat.py
@@ -1,0 +1,17 @@
+from redis.asyncio.client import Redis
+import asyncio
+import sys
+
+message = sys.argv[1]
+
+STREAM_KEY = 'stream_key'
+
+redis = Redis(
+    host="redis",
+    port="6379"
+)
+
+async def add_chat(msg):
+    await redis.xadd(STREAM_KEY, {'msg': msg})
+
+asyncio.run(add_chat(message))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - redis
     volumes:
       - .:/app
-    command: python -m uvicorn redis-stream:app --reload --host 0.0.0.0 --port 8000
+    command: python -m uvicorn redis-stream-v2:app --reload --host 0.0.0.0 --port 8000
     # command: python -m uvicorn main:app --reload
 
   redis:

--- a/redis-stream-v2.py
+++ b/redis-stream-v2.py
@@ -1,0 +1,42 @@
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from redis.asyncio.client import Redis
+import asyncio
+from fastapi.middleware.cors import CORSMiddleware
+
+STREAM_KEY = 'stream_key'
+
+redis = Redis(
+    host="redis",
+    port="6379"
+)
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    # allow_origins=origins,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+async def fake_chat_app():
+    return read_from_redis_stream()
+
+
+@app.get("/stream")
+async def main():
+    return StreamingResponse(await fake_chat_app())
+
+# =============================NEW=================================
+async def read_from_redis_stream():
+    start_id = 0
+    while True:
+        message_data = await redis.xread({STREAM_KEY: start_id}, block=5000, count=1)
+        if len(message_data) == 0:
+            break
+        message_id = message_data[0][1][0][0]
+        message_text = message_data[0][1][0][1]
+        start_id = message_id
+        yield message_text[b'msg']


### PR DESCRIPTION
Overview:
redis-stream-v2.py
This is a streaming server. 

Run test-redis-stream.py to start listening to stream.
Run: 
python add-dummy-chat.py "Your message"
In another terminal. This simulates the AI response. The response will stream to the test-redis-stream.py terminal. It will auto close if it does not receive a message after 5 seconds. 